### PR TITLE
Remove deprecated include, no longer necessary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,6 @@
   "scripts": {
     "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs",
     "post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs"
-  }
+  },
+  "type": "wordpress-plugin"
 }

--- a/inc/constraints/elements/class-oembed.php
+++ b/inc/constraints/elements/class-oembed.php
@@ -4,7 +4,6 @@ namespace Speed_Bumps\Constraints\Elements;
 class Oembed extends Constraint_Abstract {
 
 	public function paragraph_not_contains_element( $paragraph ) {
-		require_once ABSPATH . WPINC . '/class-oembed.php';
 		$wp_oembed = _wp_oembed_get_object();
 		preg_match_all( '|^\s*(https?://[^\s"]+)\s*$|im', $paragraph, $matches );
 		foreach ( $matches[1] as $match ) {


### PR DESCRIPTION
`class-oembed.php` was deprecated and now throws notice. Include no longer needed as `_wp_oembed_get_object` was moved out of class.