### PR TITLE
PHP implode arguments order

### DIFF
--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -82,7 +82,7 @@ class Speed_Bumps {
 		$last = 'class-' . $last . '.php';
 
 		$parts[] = $last;
-		$file = dirname( __FILE__ ) . '/inc/' . str_replace( '_', '-', strtolower( implode( $parts, '/' ) ) );
+		$file = dirname( __FILE__ ) . '/inc/' . str_replace( '_', '-', strtolower( implode( '/', $parts ) ) );
 
 		//If the file exists....
 		if ( file_exists( $file ) ) {


### PR DESCRIPTION
PHP 7.4.0 - Passing the separator after the array (i.e. using the legacy signature) has been deprecated.
PHP 8.0.0 - Passing the separator after the array is no longer supported.
https://www.php.net/manual/en/function.implode.php
